### PR TITLE
fix: incorrect `inet_ntop()` usage

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,13 +37,14 @@ std::string get_address()
     static const std::string default_address{"0.0.0.0"};
 
     if (const char* address = std::getenv("TFHTTP_ADDRESS"); address != nullptr) {  // NOLINT(concurrency-mt-unsafe)
-        struct sockaddr_in sa {};
+        in_addr v4{};
+        in6_addr v6{};
 
-        if (inet_pton(AF_INET, address, &sa.sin_addr) == 1) {
+        if (inet_pton(AF_INET, address, &v4) == 1) {
             return address;
         }
 
-        if (inet_pton(AF_INET6, address, &sa.sin_addr) == 1) {
+        if (inet_pton(AF_INET6, address, &v6) == 1) {
             return address;
         }
 

--- a/src/serversocket_p.cpp
+++ b/src/serversocket_p.cpp
@@ -17,11 +17,11 @@ ServerSocketPrivate::ServerSocketPrivate(const std::string& ip, std::uint16_t po
 
     SockAddr s{};
 
-    if (inet_pton(AF_INET, ip.c_str(), s.as_sockaddr_in()) == 1) {
+    if (inet_pton(AF_INET, ip.c_str(), &s.as_sockaddr_in()->sin_addr) == 1) {
         s.as_sockaddr_in()->sin_family = AF_INET;
         s.as_sockaddr_in()->sin_port   = htons(port);
     }
-    else if (inet_pton(AF_INET6, ip.c_str(), s.as_sockaddr_in6()) == 1) {
+    else if (inet_pton(AF_INET6, ip.c_str(), &s.as_sockaddr_in6()->sin6_addr) == 1) {
         s.as_sockaddr_in6()->sin6_family = AF_INET6;
         s.as_sockaddr_in6()->sin6_port   = htons(port);
     }


### PR DESCRIPTION
```ql
import cpp

from FunctionCall call, Expr afArg, Expr bufArg
where
  call.getTarget().hasName("inet_pton") and
  call.getArgument(0) = afArg and
  call.getArgument(2) = bufArg and (
    (afArg.getValue() = "2" and not bufArg.getUnderlyingType().hasName("in_addr *")) or
    (afArg.getValue() = "10" and not bufArg.getUnderlyingType().hasName("in6_addr *"))
  )
select call, "Incorrect buf argument type for inet_pton()."
```